### PR TITLE
don't throw error on empty response

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -76,7 +76,7 @@ class Client
      */
     public function send($zpl)
     {
-        if (!@socket_write($this->socket, $zpl)) {
+        if (false === @socket_write($this->socket, $zpl)) {
             $error = $this->getLastError();
             throw new CommunicationException($error['message'], $error['code']);
         }


### PR DESCRIPTION
An error with message "Success" is thrown on empty response.
