### PR TITLE
allow zpl image to take existing GD image in addition to data string

### DIFF
--- a/src/Zpl/Image.php
+++ b/src/Zpl/Image.php
@@ -93,7 +93,9 @@ class Image implements ImageContract
      */
     protected function create($data)
     {
-        if (false === $image = imagecreatefromstring($data)) {
+        if (is_resource($data) && get_resource_type($data) == 'gd') {
+		    $image = $data;
+		} elseif (false === $image = imagecreatefromstring($data)) {
             throw new RuntimeException('Could not read image.');
         }
 


### PR DESCRIPTION
Needed to add this for my project so I can pass an existing GD image resource to Zpl\Image constructor.  Useful if you are printing images you built inline.