### PR TITLE
Add support for GD library in PHP 8

### DIFF
--- a/src/Zpl/GdDecoder.php
+++ b/src/Zpl/GdDecoder.php
@@ -54,6 +54,10 @@ class GdDecoder implements Decoder
             return get_resource_type($image) === 'gd';
         }
 
+        if ($image instanceof \GdImage) {
+            return true;
+        }
+
         return false;
     }
 


### PR DESCRIPTION
Because **PHP 8** had important changes with the **GD library**, now the `is_resource` and `get_resource_type` functions do not work properly, since the objects created are not of type `resource gd`, but of type `GdImage`.
With this change, this library will continue to be compatible with PHP 7.x and earlier and with the new version 8.x. 